### PR TITLE
bug fix to config sync directory path

### DIFF
--- a/web/sites/site.settings.php
+++ b/web/sites/site.settings.php
@@ -108,7 +108,7 @@ if (!isset($settings['file_public_path'])) {
 
 // Set up a config sync directory.
 // This is defined inside the read-only "config" directory, deployed via Git.
-$settings['config_sync_directory'] = '/app/project/config/' . $subsite_id;
+$settings['config_sync_directory'] = '/app/project/config/' . $subsite_id . '/config';
 
 // Local settings. These come last so that they can override anything.
 if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {


### PR DESCRIPTION
This was causing problems with config split in Unity 2, the base config was being exported directly into the project/config/site directory when it should have been exported into project/config/site/config - this was leading to further problems with config split