### PR TITLE
Deployment bug fix

### DIFF
--- a/.hosting/platformsh/.platform.app.template.yaml
+++ b/.hosting/platformsh/.platform.app.template.yaml
@@ -98,7 +98,7 @@ hooks:
       cd /app/web/sites/$site
       drush -l $site -y cache-rebuild
       # Enable Fastly logging
-      drush enable-fastly-logging
+      drush -l $site enable-fastly-logging
     done
 
 # The configuration of app when it is exposed to the web.

--- a/.hosting/platformsh/.platform.app.template.yaml
+++ b/.hosting/platformsh/.platform.app.template.yaml
@@ -73,7 +73,7 @@ hooks:
       echo "****** $site deployment ******"
       cd /app/web/sites/$site
       # Disable Fastly logging
-      drush disable-fastly-logging
+      drush -l $site disable-fastly-logging
       # Readonlymode module should be installed on all sites,
       # but we'll just make sure.
       drush en readonlymode -l $site -y


### PR DESCRIPTION
Must specify a site when using drush to enable/disable Fastly logging